### PR TITLE
Test PR | TX_ERROR monitoring 

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -92,6 +92,7 @@ orchagent_SOURCES = \
             dtelorch.cpp \
             flexcounterorch.cpp \
             watermarkorch.cpp \
+            txmonorch.cpp \
             policerorch.cpp \
             sfloworch.cpp \
             chassisorch.cpp \

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -332,6 +332,13 @@ bool OrchDaemon::init()
         CFG_DTEL_EVENT_TABLE_NAME
     };
 
+    TableConnector stateDbTxErr(m_stateDb, /*"TX_ERR_STATE"*/STATE_TX_ERR_TABLE_NAME);
+    TableConnector applDbTxErr(m_applDb, /*"TX_ERR_APPL"*/APP_TX_ERR_TABLE_NAME);
+    TableConnector confDbTxErr(m_configDb, /*"TX_ERR_CFG"*/CFG_PORT_TX_ERR_TABLE_NAME);
+    TxMonOrch *gTxMonOrch = new TxMonOrch(applDbTxErr, confDbTxErr, stateDbTxErr);
+
+    SWSS_LOG_NOTICE("Create TxMonOrch object %p\n", gTxMonOrch);
+
     vector<string> wm_tables = {
         CFG_WATERMARK_TABLE_NAME,
         CFG_FLEX_COUNTER_TABLE_NAME
@@ -399,7 +406,7 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap. This is ensured implicitly by the order of keys in ordered map.
      * For cases when Orch has to process tables in specific order, like PortsOrch during warm start, it has to override Orch::doTask()
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gFlowCounterRouteOrch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gRouteOrch, gCoppOrch, gQosOrch, wm_orch, gPolicerOrch, tunnel_decap_orch, sflow_orch, gDebugCounterOrch, gMacsecOrch, gBfdOrch, gSrv6Orch, mux_orch, mux_cb_orch, gMonitorOrch};
+    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gFlowCounterRouteOrch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gRouteOrch, gCoppOrch, gQosOrch, wm_orch, gPolicerOrch, tunnel_decap_orch, sflow_orch, gDebugCounterOrch, gMacsecOrch, gBfdOrch, gSrv6Orch, mux_orch, mux_cb_orch, gMonitorOrch, gTxMonOrch };
 
     bool initialize_dtel = false;
     if (platform == BFN_PLATFORM_SUBSTRING || platform == VS_PLATFORM_SUBSTRING)

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -6,6 +6,7 @@
 #include "consumertable.h"
 #include "zmqserver.h"
 #include "select.h"
+#include "txmonorch.h"
 
 #include "portsorch.h"
 #include "fabricportsorch.h"

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -235,6 +235,11 @@ public:
     bool isMACsecPort(sai_object_id_t port_id) const;
     vector<sai_object_id_t> getPortVoQIds(Port& port);
 
+    bool isPortReady()
+    {
+        return m_initDone && m_pendingPortSet.empty();
+    }
+
 private:
     unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_counterSysPortTable;

--- a/orchagent/txmonorch.cpp
+++ b/orchagent/txmonorch.cpp
@@ -166,7 +166,7 @@ void TxMonOrch::doTask(Consumer& consumer)
     SWSS_LOG_ENTER();
     SWSS_LOG_INFO("TxMonOrch doTask consumer\n");
 
-    if (!(gPortsOrch->m_initDone && gPortsOrch->m_pendingPortSet.empty()))
+    if (!gPortsOrch->isPortReady())
     {
         SWSS_LOG_INFO("Ports not ready\n");
         return;

--- a/orchagent/txmonorch.cpp
+++ b/orchagent/txmonorch.cpp
@@ -1,0 +1,361 @@
+#include <linux/if_ether.h>
+
+#include <unordered_map>
+#include <utility>
+#include <exception>
+
+#include "txmonorch.h"
+#include "orch.h"
+#include "port.h"
+#include "logger.h"
+#include "sai_serialize.h"
+#include "converter.h"
+#include "portsorch.h"
+#include <vector>
+
+extern sai_port_api_t *sai_port_api;
+extern PortsOrch*       gPortsOrch;
+
+using namespace std::rel_ops;
+
+string tx_status_name [] = {"ok", "error", "unknown"};
+
+TxMonOrch::TxMonOrch(TableConnector appDbConnector, 
+                     TableConnector confDbConnector, 
+                     TableConnector stateDbConnector) :
+    Orch(confDbConnector.first, confDbConnector.second),
+    m_TxErrorTable(appDbConnector.first, appDbConnector.second),
+    m_stateTxErrorTable(stateDbConnector.first, stateDbConnector.second),
+    m_countersDb(COUNTERS_DB, DBConnector::DEFAULT_UNIXSOCKET, 0),
+    m_countersTable(&m_countersDb, COUNTERS_TABLE),
+    m_pollTimer(new SelectableTimer(timespec { .tv_sec = 0, .tv_nsec = 0 })),
+    m_PortsTxErrStat(),
+    m_pollPeriod(0)
+{
+    auto executor = new ExecutableTimer(m_pollTimer, this, TXMONORCH_SEL_TIMER);
+    Orch::addExecutor(executor);
+
+    SWSS_LOG_NOTICE("TxMonOrch initialized with table %s %s %s\n",
+                    appDbConnector.second.c_str(),
+                    stateDbConnector.second.c_str(),
+                    confDbConnector.second.c_str());
+}
+
+void TxMonOrch::startTimer(uint32_t interval)
+{
+    SWSS_LOG_ENTER();
+
+    try
+    {
+        auto interv = timespec { .tv_sec = interval, .tv_nsec = 0 };
+
+        SWSS_LOG_INFO("startTimer,  find executor %p\n", m_pollTimer);
+        m_pollTimer->setInterval(interv);
+        //is it ok to stop without having it started?
+        m_pollTimer->stop();
+        m_pollTimer->start();
+        m_pollPeriod = interval;
+    }
+    catch (...)
+    {
+        SWSS_LOG_ERROR("Failed to startTimer which might be due to failed to get timer\n");
+    }
+}
+
+int TxMonOrch::handlePeriodUpdate(const vector<FieldValueTuple>& data)
+{
+    bool needStart = false;
+    uint32_t periodToSet = 0;
+
+    SWSS_LOG_ENTER();
+
+    //is it possible for redis to combine multiple updates and notify once?
+    //if so, we handle it in this way.
+    //however, in case of that, does it respect the order in which multiple updates comming?
+    //suppose it does.
+    for (auto i : data)
+    {
+        try {
+            if (fvField(i) == TXMONORCH_FIELD_CFG_PERIOD)
+            {
+                periodToSet = to_uint<uint32_t>(fvValue(i));
+
+                needStart |= (periodToSet != m_pollPeriod);
+                SWSS_LOG_INFO("TX_ERR handle cfg update period new %d\n", periodToSet);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown field type %s\n", fvField(i).c_str());
+                return -1;
+            }
+        }
+        catch (...) {
+            SWSS_LOG_ERROR("Failed to handle period update\n");
+        }
+    }
+
+    if (needStart)
+    {
+        startTimer(periodToSet);
+        SWSS_LOG_INFO("TX_ERR poll timer restarted with interval %d\n", periodToSet);
+    }
+
+    return 0;
+}
+
+int TxMonOrch::handleThresholdUpdate(const string &port, const vector<FieldValueTuple>& data, bool clear)
+{
+    SWSS_LOG_ENTER();
+
+    try {
+        if (clear)
+        {
+            //attention, for clear, no data is empty
+            //tesThreshold(m_PortsTxErrStat[port]) = 0;
+            m_PortsTxErrStat.erase(port);
+            m_TxErrorTable.del(port);
+            m_stateTxErrorTable.del(port);
+            //todo, remove data from state_db and appl_db??
+            SWSS_LOG_INFO("TX_ERR threshold cleared for port %s\n", port.c_str());
+        }
+        else
+        {
+            for (auto i : data)
+            {
+                if (TXMONORCH_FIELD_CFG_THRESHOLD == fvField(i))
+                {
+                    TxErrorStatistics &tes = m_PortsTxErrStat[port];
+                    if (tesPortId(tes) == 0/*invalid id??*/)
+                    {
+                        //the first time this port is configured
+                        Port saiport;
+                        //what if port doesn't stand for a valid port? 
+                        //that is, getPort returns false?
+                        //what if the interface is removed with threshold configured?
+                        if (gPortsOrch->getPort(port, saiport))
+                        {
+                            tesPortId(tes) = saiport.m_port_id;
+                        }
+                        tesState(tes) = TXMONORCH_PORT_STATE_UNKNOWN;
+                    }
+                    tesThreshold(tes) = to_uint<uint64_t>(fvValue(i));
+                    SWSS_LOG_INFO("TX_ERR threshold reset to %ld for port %s\n", 
+                                  tesThreshold(tes), port.c_str());
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("Unknown field type %s when handle threshold for %s\n", 
+                                   fvField(i).c_str(), port.c_str());
+                    return -1;
+                }
+            }
+        }
+    }
+    catch (...) {
+        SWSS_LOG_ERROR("Fail to startTimer handle periodic update\n");
+    }
+
+    return 0;
+}
+
+/*handle configuration update*/
+void TxMonOrch::doTask(Consumer& consumer)
+{
+    int rc = 0;
+
+    SWSS_LOG_ENTER();
+    SWSS_LOG_INFO("TxMonOrch doTask consumer\n");
+
+    if (!(gPortsOrch->m_initDone && gPortsOrch->m_pendingPortSet.empty()))
+    {
+        SWSS_LOG_INFO("Ports not ready\n");
+        return;
+    }
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple t = it->second;
+
+        string key = kfvKey(t);
+        string op = kfvOp(t);
+        vector<FieldValueTuple> fvs = kfvFieldsValues(t);
+
+        rc = -1;
+
+        SWSS_LOG_INFO("TX_ERR %s operation %s set %s del %s\n", 
+                      key.c_str(),
+                      op.c_str(), SET_COMMAND, DEL_COMMAND);
+        if (key == TXMONORCH_KEY_CFG_PERIOD)
+        {
+            if (op == SET_COMMAND)
+            {
+                rc = handlePeriodUpdate(fvs);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown operation type %s when set period\n", op.c_str());
+            }
+        }
+        else //key should be the alias of interface
+        {
+            if (op == SET_COMMAND)
+            {
+                //fetch the value which reprsents threshold
+                rc = handleThresholdUpdate(key, fvs, false);
+            }
+            else if (op == DEL_COMMAND)
+            {
+                //reset to default
+                rc = handleThresholdUpdate(key, fvs, true);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown operation type %s when set threshold\n", op.c_str());
+            }
+        }
+
+        if (rc)
+        {
+            SWSS_LOG_ERROR("Handle configuration update failed index %s\n", key.c_str());
+        }
+
+        consumer.m_toSync.erase(it++);
+    }
+}
+
+int TxMonOrch::pollOnePortErrorStatistics(const string &port, TxErrorStatistics &stat)
+{
+    uint64_t txErrStatistics = 0,
+        txErrStatLasttime = tesStatistics(stat),
+        txErrStatThreshold = tesThreshold(stat);
+    int tx_error_state,
+        tx_error_state_lasttime = tesState(stat);
+
+    SWSS_LOG_ENTER();
+
+#if 0
+    {
+        //generate a random value instead :D
+        static uint64_t seed = 1;
+        txErrStatistics = seed;
+        txErrStatistics = txErrStatistics * 991 % 997;
+        seed = txErrStatistics;
+        txErrStatistics += txErrStatLasttime;
+        SWSS_LOG_INFO("TX_ERR_POLL: got port %s tx_err stati %d, lasttime %d threshold %d\n", 
+                      port.c_str(), txErrStatistics, txErrStatLasttime, txErrStatThreshold);
+    }
+#else
+#if 0
+    {
+        uint64_t tx_err = 0;
+        SWSS_LOG_INFO("TX_ERR_POLL: got port %s %lx tx_err stati %ld, lasttime %ld threshold %ld\n", 
+                      port.c_str(), tesPortId(stat),
+                      txErrStatistics, txErrStatLasttime, txErrStatThreshold);
+        vector<FieldValueTuple> fieldValues;
+
+        if (m_countersTable.get(sai_serialize_object_id(tesPortId(stat)), fieldValues))
+        {
+            SWSS_LOG_INFO("TX_ERR_POLL: got port %s %lx statistics, parsing... \n", port.c_str(), tesPortId(stat));
+            for (const auto& fv : fieldValues)
+            {
+                const auto field = fvField(fv);
+                const auto value = fvValue(fv);
+
+
+                if (field == "SAI_PORT_STAT_IF_OUT_ERRORS")
+                {
+                    tx_err = stoul(value);
+                    SWSS_LOG_INFO("    TX_ERR_POLL: %s found %ld %s\n", 
+                                  field.c_str(), tx_err, value.c_str());
+                    break;
+                }
+            }
+        }
+        else
+        {
+            SWSS_LOG_INFO("TX_ERR_POLL: failed to get port %s %lx \n", port.c_str(), tesPortId(stat));
+        }
+        txErrStatistics = tx_err;
+        SWSS_LOG_INFO("TX_ERR_POLL: got port %s tx_err stati %ld, lasttime %ld threshold %ld\n", 
+                      port.c_str(), txErrStatistics, txErrStatLasttime, txErrStatThreshold);
+    }
+#endif
+    {
+        static const vector<sai_stat_id_t> txErrStatId = {SAI_PORT_STAT_IF_OUT_ERRORS};
+        uint64_t tx_err = -1;
+        //get statistics from hal
+        //check FlexCounter::saiUpdateSupportedPortCounters in sai-redis for reference
+        sai_port_api->get_port_stats(tesPortId(stat),
+                                     static_cast<uint32_t>(txErrStatId.size()),
+                                     txErrStatId.data(),
+                                     &tx_err);
+        txErrStatistics = tx_err;
+        SWSS_LOG_INFO("TX_ERR_POLL: got port %s tx_err stati %ld, lasttime %ld threshold %ld\n", 
+                      port.c_str(), txErrStatistics, txErrStatLasttime, txErrStatThreshold);
+    }
+
+#endif
+
+    if (txErrStatistics - txErrStatLasttime > txErrStatThreshold)
+    {
+        tx_error_state = TXMONORCH_PORT_STATE_ERROR;
+    }
+    else
+    {
+        tx_error_state = TXMONORCH_PORT_STATE_OK;
+    }
+    if (tx_error_state != tx_error_state_lasttime)
+    {
+        tesState(stat) = tx_error_state;
+        //set status in STATE_DB
+        vector<FieldValueTuple> fvs;
+		if (tx_error_state < TXMONORCH_PORT_STATE_MAX)
+            fvs.emplace_back(TXMONORCH_FIELD_STATE_TX_STATE, tx_status_name[tx_error_state]);
+		else
+            fvs.emplace_back(TXMONORCH_FIELD_STATE_TX_STATE, "invalid");
+        m_stateTxErrorTable.set(port, fvs);
+        SWSS_LOG_INFO("TX_ERR_CFG: port %s state changed to %d, push to db\n", port.c_str(), tx_error_state);
+    }
+
+    //refresh the local copy of last time statistics
+    tesStatistics(stat) = txErrStatistics;
+
+    return 0;
+}
+
+void TxMonOrch::pollErrorStatistics()
+{
+    SWSS_LOG_ENTER();
+
+    KeyOpFieldsValuesTuple portEntry;
+
+    for (auto i : m_PortsTxErrStat)
+    {
+        vector<FieldValueTuple> fields;
+        int rc;
+
+        SWSS_LOG_INFO("TX_ERR_APPL: port %s tx_err_stat %ld, before get\n", i.first.c_str(),
+                        tesStatistics(i.second));
+        rc = pollOnePortErrorStatistics(i.first, i.second);
+        if (rc != 0)
+            SWSS_LOG_ERROR("TX_ERR_APPL: got port %s tx_err_stat failed %d\n", i.first.c_str(), rc);
+        fields.emplace_back(TXMONORCH_FIELD_APPL_STATI, to_string(tesStatistics(i.second)));
+        fields.emplace_back(TXMONORCH_FIELD_APPL_TIMESTAMP, "0");
+        fields.emplace_back(TXMONORCH_FIELD_APPL_SAIPORTID, to_string(tesPortId(i.second)));
+        m_TxErrorTable.set(i.first, fields);
+        SWSS_LOG_INFO("TX_ERR_APPL: port %s tx_err_stat %ld, push to db\n", i.first.c_str(),
+                        tesStatistics(i.second));
+    }
+
+    m_TxErrorTable.flush();
+    m_stateTxErrorTable.flush();
+    SWSS_LOG_INFO("TX_ERR_APPL: flushing tables\n");
+}
+
+void TxMonOrch::doTask(SelectableTimer &timer)
+{
+    SWSS_LOG_INFO("TxMonOrch doTask selectable timer\n");
+    //for each ports, check the statisticis 
+    pollErrorStatistics();
+}

--- a/orchagent/txmonorch.h
+++ b/orchagent/txmonorch.h
@@ -60,6 +60,12 @@ public:
     TxMonOrch(TableConnector appDbConnector, 
               TableConnector confDbConnector, 
               TableConnector stateDbConnector);
+    
+    void startTimer(uint32_t interval);
+    int handlePeriodUpdate(const vector<FieldValueTuple>& data);
+    int handleThresholdUpdate(const string &key, const vector<FieldValueTuple>& data, bool clear);
+    int pollOnePortErrorStatistics(const string &port, TxErrorStatistics &stat);
+    void pollErrorStatistics();
 
 private:
     //ProducerStateTable is designed to provide a IPC ability, 
@@ -82,11 +88,5 @@ private:
 
     void doTask(Consumer& consumer);
     void doTask(SelectableTimer &timer);
-
-    void startTimer(uint32_t interval);
-    int handlePeriodUpdate(const vector<FieldValueTuple>& data);
-    int handleThresholdUpdate(const string &key, const vector<FieldValueTuple>& data, bool clear);
-    int pollOnePortErrorStatistics(const string &port, TxErrorStatistics &stat);
-    void pollErrorStatistics();
 };
 #endif /* SWSS_TXMONORCH_H */

--- a/orchagent/txmonorch.h
+++ b/orchagent/txmonorch.h
@@ -1,0 +1,92 @@
+#ifndef SWSS_TXMONORCH_H
+#define SWSS_TXMONORCH_H
+
+#include "orch.h"
+#include "producerstatetable.h"
+#include "observer.h"
+#include "portsorch.h"
+#include "selectabletimer.h"
+#include "table.h"
+#include "select.h"
+#include "timer.h"
+
+#include <map>
+#include <algorithm>
+#include <tuple>
+#include <inttypes.h>
+
+extern "C" {
+#include "sai.h"
+}
+
+/*fields definition*/
+#define TXMONORCH_FIELD_CFG_PERIOD      "tx_error_check_period"
+#define TXMONORCH_FIELD_CFG_THRESHOLD       "tx_error_threshold"
+
+#define TXMONORCH_FIELD_APPL_STATI      "tx_error_stati"
+#define TXMONORCH_FIELD_APPL_TIMESTAMP  "tx_error_timestamp"
+#define TXMONORCH_FIELD_APPL_SAIPORTID  "tx_error_portid"
+
+#define TXMONORCH_FIELD_STATE_TX_STATE  "tx_status"
+
+/*key name definition*/
+/*key name for each port is its intf name*/
+/*key name of global period*/
+#define TXMONORCH_KEY_CFG_PERIOD    "GLOBAL_PERIOD" 
+
+/*table names are defined in schema.h*/
+
+#define TXMONORCH_ERR_STATE     "tx_status"
+
+#define TXMONORCH_SEL_TIMER     "TX_ERR_COUNTERS_POLL"
+
+/*tx state definition*/
+#define TXMONORCH_PORT_STATE_OK         0
+#define TXMONORCH_PORT_STATE_ERROR      1
+#define TXMONORCH_PORT_STATE_UNKNOWN    2
+#define TXMONORCH_PORT_STATE_MAX        3
+
+typedef std::tuple<int, sai_object_id_t, uint64_t, uint64_t> TxErrorStatistics;//state, stati, threshold
+typedef std::map<std::string, TxErrorStatistics> TxErrorStatMap;
+
+#define tesState std::get<0>
+#define tesPortId std::get<1>
+#define tesStatistics std::get<2>
+#define tesThreshold std::get<3>
+
+class TxMonOrch : public Orch
+{
+public:
+    TxMonOrch(TableConnector appDbConnector, 
+              TableConnector confDbConnector, 
+              TableConnector stateDbConnector);
+
+private:
+    //ProducerStateTable is designed to provide a IPC ability, 
+    //Table is designed for data persistence.
+    //representing PORT_TX_STATISTICS_TABLE in APPL_DB
+    Table m_TxErrorTable;
+    //representing PORT_TX_STAT_TABLE in STATE_DB
+    Table m_stateTxErrorTable;
+
+    //for fetching statistics
+    DBConnector m_countersDb;
+    Table m_countersTable;
+
+    TxErrorStatMap m_PortsTxErrStat;
+
+    /*should be accessed via an atomic approach?*/
+    uint32_t m_pollPeriod;
+    int m_poolPeriodChanged;
+    SelectableTimer *m_pollTimer;
+
+    void doTask(Consumer& consumer);
+    void doTask(SelectableTimer &timer);
+
+    void startTimer(uint32_t interval);
+    int handlePeriodUpdate(const vector<FieldValueTuple>& data);
+    int handleThresholdUpdate(const string &key, const vector<FieldValueTuple>& data, bool clear);
+    int pollOnePortErrorStatistics(const string &port, TxErrorStatistics &stat);
+    void pollErrorStatistics();
+};
+#endif /* SWSS_TXMONORCH_H */

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -54,6 +54,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 intfsorch_ut.cpp \
                 mux_rollback_ut.cpp \
                 warmrestartassist_ut.cpp \
+                txmonorch_ut.cpp \
                 test_failure_handling.cpp \
                 $(top_srcdir)/lib/gearboxutils.cpp \
                 $(top_srcdir)/lib/subintf.cpp \

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -103,6 +103,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/dtelorch.cpp \
                 $(top_srcdir)/orchagent/flexcounterorch.cpp \
                 $(top_srcdir)/orchagent/watermarkorch.cpp \
+                $(top_srcdir)/orchagent/txmonorch.cpp \
                 $(top_srcdir)/orchagent/chassisorch.cpp \
                 $(top_srcdir)/orchagent/sfloworch.cpp \
                 $(top_srcdir)/orchagent/debugcounterorch.cpp \

--- a/tests/mock_tests/txmonorch_ut.cpp
+++ b/tests/mock_tests/txmonorch_ut.cpp
@@ -1,0 +1,421 @@
+#define private public // make Directory::m_values available to clean it.
+#include "directory.h"
+#undef private
+
+#include "gtest/gtest.h"
+#include "mock_table.h"
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "txmonorch.h"
+
+namespace txmonorch_test 
+{
+    using namespace std;
+
+    // copy from portorch_ut.cpp, logic to mock some sai APIs.
+
+        // SAI default ports
+    std::map<std::string, std::vector<swss::FieldValueTuple>> defaultPortList;
+
+    sai_port_api_t ut_sai_port_api;
+    sai_port_api_t *pold_sai_port_api;
+    sai_switch_api_t ut_sai_switch_api;
+    sai_switch_api_t *pold_sai_switch_api;
+
+    bool not_support_fetching_fec;
+    uint32_t _sai_set_port_fec_count;
+    int32_t _sai_port_fec_mode;
+    vector<sai_port_fec_mode_t> mock_port_fec_modes = {SAI_PORT_FEC_MODE_RS, SAI_PORT_FEC_MODE_FC};
+
+    sai_status_t _ut_stub_sai_get_port_attribute(
+        _In_ sai_object_id_t port_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list)
+    {
+        sai_status_t status;
+        if (attr_count == 1 && attr_list[0].id == SAI_PORT_ATTR_SUPPORTED_FEC_MODE)
+        {
+            if (not_support_fetching_fec)
+            {
+                status = SAI_STATUS_NOT_IMPLEMENTED;
+            }
+            else
+            {
+                uint32_t i;
+                for (i = 0; i < attr_list[0].value.s32list.count && i < mock_port_fec_modes.size(); i++)
+                {
+                    attr_list[0].value.s32list.list[i] = mock_port_fec_modes[i];
+                }
+                attr_list[0].value.s32list.count = i;
+                status = SAI_STATUS_SUCCESS;
+            }
+        }
+        else if (attr_count == 1 && attr_list[0].id == SAI_PORT_ATTR_OPER_PORT_FEC_MODE)
+        {
+            attr_list[0].value.s32 = _sai_port_fec_mode;
+            status = SAI_STATUS_SUCCESS;
+        }
+        else
+        {
+            status = pold_sai_port_api->get_port_attribute(port_id, attr_count, attr_list);
+        }
+        return status;
+    }
+
+    uint32_t _sai_set_pfc_mode_count;
+    uint32_t _sai_set_admin_state_up_count;
+    uint32_t _sai_set_admin_state_down_count;
+    sai_status_t _ut_stub_sai_set_port_attribute(
+        _In_ sai_object_id_t port_id,
+        _In_ const sai_attribute_t *attr)
+    {
+        if (attr[0].id == SAI_PORT_ATTR_FEC_MODE)
+        {
+            _sai_set_port_fec_count++;
+            _sai_port_fec_mode = attr[0].value.s32;
+        }
+        else if (attr[0].id == SAI_PORT_ATTR_AUTO_NEG_MODE)
+        {
+            /* Simulating failure case */
+            return SAI_STATUS_FAILURE;
+        }
+	else if (attr[0].id == SAI_PORT_PRIORITY_FLOW_CONTROL_MODE_COMBINED)
+	{
+	    _sai_set_pfc_mode_count++;
+        }
+	else if (attr[0].id == SAI_PORT_ATTR_ADMIN_STATE)
+	{
+            if (attr[0].value.booldata) {
+	        _sai_set_admin_state_up_count++;
+            } else {
+	        _sai_set_admin_state_down_count++;
+            }
+        }
+        return pold_sai_port_api->set_port_attribute(port_id, attr);
+    }
+
+    uint32_t *_sai_syncd_notifications_count;
+    int32_t *_sai_syncd_notification_event;
+    uint32_t _sai_switch_dlr_packet_action_count;
+    uint32_t _sai_switch_dlr_packet_action;
+    sai_status_t _ut_stub_sai_set_switch_attribute(
+        _In_ sai_object_id_t switch_id,
+        _In_ const sai_attribute_t *attr)
+    {
+        if (attr[0].id == SAI_REDIS_SWITCH_ATTR_NOTIFY_SYNCD)
+        {
+            *_sai_syncd_notifications_count =+ 1;
+            *_sai_syncd_notification_event = attr[0].value.s32;
+        }
+	else if (attr[0].id == SAI_SWITCH_ATTR_PFC_DLR_PACKET_ACTION)
+        {
+	    _sai_switch_dlr_packet_action_count++;
+	    _sai_switch_dlr_packet_action = attr[0].value.s32;
+	}
+        return pold_sai_switch_api->set_switch_attribute(switch_id, attr);
+    }
+
+    void _hook_sai_port_api()
+    {
+        ut_sai_port_api = *sai_port_api;
+        pold_sai_port_api = sai_port_api;
+        ut_sai_port_api.get_port_attribute = _ut_stub_sai_get_port_attribute;
+        ut_sai_port_api.set_port_attribute = _ut_stub_sai_set_port_attribute;
+        sai_port_api = &ut_sai_port_api;
+    }
+
+    void _unhook_sai_port_api()
+    {
+        sai_port_api = pold_sai_port_api;
+    }
+
+    void _hook_sai_switch_api()
+    {
+        ut_sai_switch_api = *sai_switch_api;
+        pold_sai_switch_api = sai_switch_api;
+        ut_sai_switch_api.set_switch_attribute = _ut_stub_sai_set_switch_attribute;
+        sai_switch_api = &ut_sai_switch_api;
+    }
+
+    void _unhook_sai_switch_api()
+    {
+        sai_switch_api = pold_sai_switch_api;
+    }
+
+    sai_queue_api_t ut_sai_queue_api;
+    sai_queue_api_t *pold_sai_queue_api;
+    int _sai_set_queue_attr_count = 0;
+
+    sai_status_t _ut_stub_sai_set_queue_attribute(sai_object_id_t queue_id, const sai_attribute_t *attr)
+    {
+        if(attr->id == SAI_QUEUE_ATTR_PFC_DLR_INIT)
+        {
+            if(attr->value.booldata == true)
+            {
+                _sai_set_queue_attr_count++;
+            }
+            else
+            {
+                _sai_set_queue_attr_count--;
+            }
+        }
+        return SAI_STATUS_SUCCESS;
+    }
+
+
+    // Define a test fixture class
+    struct TxMonOrchTest : public ::testing::Test 
+    {
+        shared_ptr<swss::DBConnector> m_app_db;
+        shared_ptr<swss::DBConnector> m_config_db;
+        shared_ptr<swss::DBConnector> m_state_db;
+        shared_ptr<swss::DBConnector> m_counters_db;
+        shared_ptr<swss::DBConnector> m_chassis_app_db;
+        shared_ptr<swss::DBConnector> m_asic_db;
+
+        TxMonOrchTest()
+        {
+            // again, logics come from portorch_ut.cpp
+            
+            // FIXME: move out from constructor
+            m_app_db = make_shared<swss::DBConnector>(
+                "APPL_DB", 0);
+            m_counters_db = make_shared<swss::DBConnector>(
+                "COUNTERS_DB", 0);
+            m_config_db = make_shared<swss::DBConnector>(
+                "CONFIG_DB", 0);
+            m_state_db = make_shared<swss::DBConnector>(
+                "STATE_DB", 0);
+            m_chassis_app_db = make_shared<swss::DBConnector>(
+                "CHASSIS_APP_DB", 0);
+            m_asic_db = make_shared<swss::DBConnector>(
+                "ASIC_DB", 0);
+        }
+
+        virtual void SetUp() override
+        {
+            ::testing_db::reset();
+
+            // Create dependencies ...
+            TableConnector stateDbSwitchTable(m_state_db.get(), "SWITCH_CAPABILITY");
+            TableConnector app_switch_table(m_app_db.get(), APP_SWITCH_TABLE_NAME);
+            TableConnector conf_asic_sensors(m_config_db.get(), CFG_ASIC_SENSORS_TABLE_NAME);
+
+            vector<TableConnector> switch_tables = {
+                conf_asic_sensors,
+                app_switch_table
+            };
+
+            ASSERT_EQ(gSwitchOrch, nullptr);
+            gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
+
+            const int portsorch_base_pri = 40;
+
+            vector<table_name_with_pri_t> ports_tables = {
+                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
+                { APP_SEND_TO_INGRESS_PORT_TABLE_NAME, portsorch_base_pri + 5 },
+                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
+                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
+                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
+                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            };
+
+            ASSERT_EQ(gPortsOrch, nullptr);
+
+            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
+
+            vector<string> flex_counter_tables = {
+                CFG_FLEX_COUNTER_TABLE_NAME
+            };
+            auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
+            gDirectory.set(flexCounterOrch);
+
+            vector<string> buffer_tables = { APP_BUFFER_POOL_TABLE_NAME,
+                                             APP_BUFFER_PROFILE_TABLE_NAME,
+                                             APP_BUFFER_QUEUE_TABLE_NAME,
+                                             APP_BUFFER_PG_TABLE_NAME,
+                                             APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME,
+                                             APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME };
+
+            //ASSERT_EQ(gBufferOrch, nullptr);
+            //gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
+
+            ASSERT_EQ(gIntfsOrch, nullptr);
+            gIntfsOrch = new IntfsOrch(m_app_db.get(), APP_INTF_TABLE_NAME, gVrfOrch, m_chassis_app_db.get());
+
+            const int fdborch_pri = 20;
+
+            vector<table_name_with_pri_t> app_fdb_tables = {
+                { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri},
+                { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri},
+                { APP_MCLAG_FDB_TABLE_NAME,  fdborch_pri}
+            };
+
+            TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);
+            TableConnector stateMclagDbFdb(m_state_db.get(), STATE_MCLAG_REMOTE_FDB_TABLE_NAME);
+            ASSERT_EQ(gFdbOrch, nullptr);
+            gFdbOrch = new FdbOrch(m_app_db.get(), app_fdb_tables, stateDbFdb, stateMclagDbFdb, gPortsOrch);
+
+            ASSERT_EQ(gNeighOrch, nullptr);
+            gNeighOrch = new NeighOrch(m_app_db.get(), APP_NEIGH_TABLE_NAME, gIntfsOrch, gFdbOrch, gPortsOrch, m_chassis_app_db.get());
+
+            vector<string> qos_tables = {
+                CFG_TC_TO_QUEUE_MAP_TABLE_NAME,
+                CFG_SCHEDULER_TABLE_NAME,
+                CFG_DSCP_TO_TC_MAP_TABLE_NAME,
+                CFG_MPLS_TC_TO_TC_MAP_TABLE_NAME,
+                CFG_DOT1P_TO_TC_MAP_TABLE_NAME,
+                CFG_QUEUE_TABLE_NAME,
+                CFG_PORT_QOS_MAP_TABLE_NAME,
+                CFG_WRED_PROFILE_TABLE_NAME,
+                CFG_TC_TO_PRIORITY_GROUP_MAP_TABLE_NAME,
+                CFG_PFC_PRIORITY_TO_PRIORITY_GROUP_MAP_TABLE_NAME,
+                CFG_PFC_PRIORITY_TO_QUEUE_MAP_TABLE_NAME,
+                CFG_DSCP_TO_FC_MAP_TABLE_NAME,
+                CFG_EXP_TO_FC_MAP_TABLE_NAME,
+                CFG_TC_TO_DSCP_MAP_TABLE_NAME
+            };
+            gQosOrch = new QosOrch(m_config_db.get(), qos_tables);
+
+            vector<string> pfc_wd_tables = {
+                CFG_PFC_WD_TABLE_NAME
+            };
+
+            static const vector<sai_port_stat_t> portStatIds =
+            {
+                SAI_PORT_STAT_PFC_0_RX_PKTS,
+                SAI_PORT_STAT_PFC_1_RX_PKTS,
+                SAI_PORT_STAT_PFC_2_RX_PKTS,
+                SAI_PORT_STAT_PFC_3_RX_PKTS,
+                SAI_PORT_STAT_PFC_4_RX_PKTS,
+                SAI_PORT_STAT_PFC_5_RX_PKTS,
+                SAI_PORT_STAT_PFC_6_RX_PKTS,
+                SAI_PORT_STAT_PFC_7_RX_PKTS,
+                SAI_PORT_STAT_PFC_0_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_1_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_2_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_3_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_4_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_5_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_6_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_7_ON2OFF_RX_PKTS,
+            };
+
+            static const vector<sai_queue_stat_t> queueStatIds =
+            {
+                SAI_QUEUE_STAT_PACKETS,
+                SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES,
+            };
+
+            static const vector<sai_queue_attr_t> queueAttrIds =
+            {
+                SAI_QUEUE_ATTR_PAUSE_STATUS,
+            };
+            ASSERT_EQ((gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>), nullptr);
+            gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler> = new PfcWdSwOrch<PfcWdDlrHandler, PfcWdDlrHandler>(m_config_db.get(), pfc_wd_tables, portStatIds, queueStatIds, queueAttrIds, 100);
+
+        }
+
+        virtual void TearDown() override
+        {
+            ::testing_db::reset();
+
+            auto buffer_maps = BufferOrch::m_buffer_type_maps;
+            for (auto &i : buffer_maps)
+            {
+                i.second->clear();
+            }
+
+            delete gNeighOrch;
+            gNeighOrch = nullptr;
+            delete gFdbOrch;
+            gFdbOrch = nullptr;
+            delete gIntfsOrch;
+            gIntfsOrch = nullptr;
+            delete gPortsOrch;
+            gPortsOrch = nullptr;
+            delete gBufferOrch;
+            gBufferOrch = nullptr;
+            delete gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>;
+            gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler> = nullptr;
+            delete gQosOrch;
+            gQosOrch = nullptr;
+            delete gSwitchOrch;
+            gSwitchOrch = nullptr;
+
+            // clear orchs saved in directory
+            gDirectory.m_values.clear();
+        }
+
+        static void SetUpTestCase()
+        {
+            // Init switch and create dependencies
+
+            map<string, string> profile = {
+                { "SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850" },
+                { "KV_DEVICE_MAC_ADDRESS", "20:03:04:05:06:00" }
+            };
+
+            auto status = ut_helper::initSaiApi(profile);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            sai_attribute_t attr;
+
+            attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+            attr.value.booldata = true;
+
+            status = sai_switch_api->create_switch(&gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            // Get switch source MAC address
+            attr.id = SAI_SWITCH_ATTR_SRC_MAC_ADDRESS;
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gMacAddress = attr.value.mac;
+
+            // Get the default virtual router ID
+            attr.id = SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID;
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gVirtualRouterId = attr.value.oid;
+
+            // Get SAI default ports
+            defaultPortList = ut_helper::getInitialSaiPorts();
+            ASSERT_TRUE(!defaultPortList.empty());
+        }
+
+        static void TearDownTestCase()
+        {
+            auto status = sai_switch_api->remove_switch(gSwitchId);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+            gSwitchId = 0;
+
+            ut_helper::uninitSaiApi();
+        }
+    };
+
+    // We don't have API for checking period and threshold independtly
+    TEST_F(TxMonOrchTest, pollOnePortErrorStatisticsTest) {
+        TableConnector stateDbTxErr(m_state_db.get(), /*"TX_ERR_STATE"*/STATE_TX_ERR_TABLE_NAME);
+        TableConnector applDbTxErr(m_app_db.get(), /*"TX_ERR_APPL"*/APP_TX_ERR_TABLE_NAME);
+        TableConnector confDbTxErr(m_config_db.get(), /*"TX_ERR_CFG"*/CFG_PORT_TX_ERR_TABLE_NAME);
+        TxMonOrch txMonOrch(applDbTxErr, confDbTxErr, stateDbTxErr);
+        TxErrorStatistics stat;
+        vector<FieldValueTuple> period {{TXMONORCH_FIELD_CFG_PERIOD, "1"}};
+        vector<FieldValueTuple> threshold {{TXMONORCH_FIELD_CFG_THRESHOLD, "10"}};
+        txMonOrch.pollOnePortErrorStatistics("2", stat);
+        // cout << tesState(stat) << " ";
+        // cout << tesPortId(stat) << " ";
+        // cout << tesStatistics(stat) << " ";
+        // cout << tesThreshold(stat) << " ";
+        EXPECT_TRUE(tesState(stat) == TXMONORCH_PORT_STATE_OK);
+        EXPECT_TRUE(tesPortId(stat) == 1);
+        EXPECT_TRUE(tesStatistics(stat) == 0);
+        EXPECT_TRUE(tesThreshold(stat) == 10);
+    }
+
+}


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add facilities for tx error monitoring.

add class TxMonOrch, which:
is derived from Orch,
handles CONFIG_DB updates in doTask(Consumer&)
handles polling timer expiring in doTask(SelectableTimer&)
retrieve TX ERROR statistics for each port configured
make use of Table class to push data to APPL_DB and STATE_DB
add initialization for a TxMonOrch object in orchdaemon.cpp.

**Why I did it**
For NE Training Lab 5

**How I verified it**
Add related unit tests and verified it manually by building and testing image

**Details if related**
