### PR TITLE
Avoid removing a VRF routing table when there are pending creation en…

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2433,13 +2433,21 @@ bool RouteOrch::removeRoute(RouteBulkContext& ctx)
     size_t creating = gRouteBulker.creating_entries_count(route_entry);
     if (it_route == it_route_table->second.end() && creating == 0)
     {
-       if (it_route_table->second.size() == 0)
-       {
+        /*
+         * Clean up the VRF routing table if
+         * 1. there is no routing entry in the VRF routing table and
+         * 2. there is no pending bulk creation routing entry in gRouteBulker
+         * The ideal way of the 2nd condition is to check pending bulk creation entries of a certain VRF.
+         * However, we can not do that unless going over all entries in gRouteBulker.
+         * So, we use above strict conditions here
+         */
+        if (it_route_table->second.size() == 0 && gRouteBulker.creating_entries_count() == 0)
+        {
             m_syncdRoutes.erase(vrf_id);
             m_vrfOrch->decreaseVrfRefCount(vrf_id);
-       }
-       SWSS_LOG_INFO("Failed to find route entry, vrf_id 0x%" PRIx64 ", prefix %s\n", vrf_id,
-                     ipPrefix.to_string().c_str());
+        }
+        SWSS_LOG_INFO("Failed to find route entry, vrf_id 0x%" PRIx64 ", prefix %s\n", vrf_id,
+                      ipPrefix.to_string().c_str());
  
         return true;
     }

--- a/orchagent/swssnet.h
+++ b/orchagent/swssnet.h
@@ -21,6 +21,7 @@ inline static sai_ip_address_t& copy(sai_ip_address_t& dst, const IpAddress& src
     switch(sip.family)
     {
         case AF_INET:
+            memset((void*)&dst.addr, 0, sizeof(dst.addr));
             dst.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
             dst.addr.ip4 = sip.ip_addr.ipv4_addr;
             break;
@@ -41,6 +42,7 @@ inline static sai_ip_prefix_t& copy(sai_ip_prefix_t& dst, const IpPrefix& src)
     switch(ia.family)
     {
         case AF_INET:
+            memset((void*)&dst, 0, sizeof(dst));
             dst.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
             dst.addr.ip4 = ia.ip_addr.ipv4_addr;
             dst.mask.ip4 = ma.ip_addr.ipv4_addr;
@@ -62,6 +64,7 @@ inline static sai_ip_prefix_t& copy(sai_ip_prefix_t& dst, const IpAddress& src)
     switch(sip.family)
     {
         case AF_INET:
+            memset((void*)&dst, 0, sizeof(dst));
             dst.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
             dst.addr.ip4 = sip.ip_addr.ipv4_addr;
             dst.mask.ip4 = 0xFFFFFFFF;


### PR DESCRIPTION
…tries in gRouteBulker (#3477)

* Set bytes to 0 before copying IPv4 addresses/masks to avoid uninitialized bytes
* Avoid removing a VRF routing table when there are pending creation entries in gRouteBulker

Remove a VRF routing table when a routing entry is removed only if there is no pending creation entry in gRouteBulker Avoid uninitialized value SAI IP address/prefix structure Why I did it

Fix issue: out of range exception can be thrown in addRoutePost due to non exist VRF

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
